### PR TITLE
Enable cookies to be available at response with Onyx::HTTP::Spec

### DIFF
--- a/src/onyx/http/spec.cr
+++ b/src/onyx/http/spec.cr
@@ -79,6 +79,11 @@ module Onyx::HTTP
       def headers : ::HTTP::Headers
         @response.headers
       end
+      
+      # `#response`'s cookies.
+      def cookies : ::HTTP::Cookies
+        @response.cookies
+      end
 
       # Assert response *status_code*.
       def assert(status_code : Int)


### PR DESCRIPTION
I came across a case when I need to check a cookie from an HTTP request's response at testing.